### PR TITLE
Pin alpine version to 3.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@
 #
 # Dockerfile for guacamole-server
 #
-ARG ALPINE_BASE_IMAGE=latest
+
+# The Alpine Linux image that should be used as the basis for the guacd image
+# NOTE: Using 3.22.2 because later versions of alpine uses cmake 4
+# but libvncserver requires cmake < 4.
+ARG ALPINE_BASE_IMAGE=3.22.2
 
 # The target architecture of the build. Valid values are "ARM" and "X86". By
 # default, this is detected automatically.


### PR DESCRIPTION
Pin alpine version to 3.22.2. Alpine >=3.23 uses cmake 4 and libvncserver requires cmake < 4

Not yet included in latest release: https://github.com/LibVNC/libvncserver/commit/e64fa928170f22a2e21b5bbd6d46c8f8e7dd7a96